### PR TITLE
Fix _reposense/config.json and project advisor's photo not showing properly

### DIFF
--- a/_reposense/config.json
+++ b/_reposense/config.json
@@ -4,27 +4,27 @@
     {
       "githubId": "HEARTOFAL1ON",
       "displayName": "DANIE...E YAO",
-      "authorNames": ["HEARTOFAL1ON"],
-    }
+      "authorNames": ["HEARTOFAL1ON"]
+    },
     {
       "githubId": "ChengYuuu",
       "displayName": "GOH C...NG YU",
-      "authorNames": ["ChengYuuu"],
-    }
+      "authorNames": ["ChengYuuu"]
+    },
     {
       "githubId": "Hexinyiyi",
       "displayName": "HE ...NYI",
-      "authorNames": ["Hexinyiyi"],
-    }
+      "authorNames": ["Hexinyiyi"]
+    },
     {
       "githubId": "jiacheng-panda",
       "displayName": "WU JI...CHENG",
-      "authorNames": ["jiacheng-panda"],
-    }
+      "authorNames": ["jiacheng-panda"]
+    },
     {
       "githubId": "YezhongZ",
       "displayName": "ZHANG...ZHONG",
-      "authorNames": ["YezhongZ"],
+      "authorNames": ["YezhongZ"]
     }
   ]
 }

--- a/docs/AboutUs.adoc
+++ b/docs/AboutUs.adoc
@@ -12,7 +12,7 @@ We are a team based in the http://www.comp.nus.edu.sg[School of Computing, Natio
 == Project Team
 
 === RAJAPAKSE, Damith Chatura
-image::damithc.jpg[width="150", align="left"]
+image::damithc.png[width="150", align="left"]
 {empty}[http://www.comp.nus.edu.sg/~damithch[homepage]] [https://github.com/damithc[github]] [<<johndoe#, portfolio>>]
 
 Role: Project Advisor


### PR DESCRIPTION
- Update `_reposense/config.json` to what is shown on: 
https://nus-cs2103-ay1819s1.github.io/cs2103-website/admin/reposenseConfigTemplates.html#f11-1
- Fix issue where Project Advisor's photo is shown as a broken link in "About Us" of our GitHub pages